### PR TITLE
Add only non-null default pool Security Context values

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -421,9 +421,15 @@ func poolContainerSecurityContext(pool *miniov2.Pool) *v1.SecurityContext {
 	var runAsGroup int64 = 1000
 	// Default to Pod values
 	if pool.SecurityContext != nil {
-		runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
-		runAsUser = *pool.SecurityContext.RunAsUser
-		runAsGroup = *pool.SecurityContext.RunAsGroup
+		if pool.SecurityContext.RunAsNonRoot != nil {
+			runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
+		}
+		if pool.SecurityContext.RunAsUser != nil {
+			runAsUser = *pool.SecurityContext.RunAsUser
+		}
+		if pool.SecurityContext.RunAsGroup != nil {
+			runAsGroup = *pool.SecurityContext.RunAsGroup
+		}
 	}
 
 	containerSecurityContext := corev1.SecurityContext{


### PR DESCRIPTION
## Issue
From Cesar, 
_Issue comes from file github.com/minio/operator/pkg/resources/statefulsets/minio-statefulset.go:424 because we cannot longer support securityContext: {} in our Tenant Specification under pools option as before. I think we are trying to get some values from an empty context:_
```
	// Default to Pod values
	if pool.SecurityContext != nil {
		runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
		runAsUser = *pool.SecurityContext.RunAsUser
		runAsGroup = *pool.SecurityContext.RunAsGroup
	}
```
_PR was: https://github.com/minio/operator/pull/1372_

_We should fix above issue/panic and still support securityContext: {} under pools in Tenant Specification._

## Reproduce
1. Deploy and maintain a kind cluster with tenant-lite. e.g. with `testing/deploy-tenant.sh` in the operator repo.
Ensure that the `destroy_kind` command is commented out.

2. Once the tenant pods are online, edit the tenant ensuring the following is under `.spec.pools`, with `k -n tenant-lite edit tenants.minio.min.io`:
```
    securityContext:
      #runAsUser: 1000
      #runAsGroup: 1000
      #runAsNonRoot: true
      fsGroup: 1000
    containerSecurityContext:
      runAsUser: 1000       
      runAsGroup: 1000
      runAsNonRoot: true
```

![image](https://user-images.githubusercontent.com/16472240/213004912-234492c8-e610-4745-8d45-58535bd556ae.png)


3. Restart the tenant pods, and observe them in a non ready state
```
k -n tenant-lite delete pod/storage-lite-pool-0-0
k -n tenant-lite delete pod/storage-lite-pool-0-1
k -n tenant-lite delete pod/storage-lite-pool-0-2
k -n tenant-lite delete pod/storage-lite-pool-0-3
```
```
k -n tenant-lite get pods | grep "pool-0"
```
![image](https://user-images.githubusercontent.com/16472240/213006728-d303eed1-9ebd-4dc4-bf37-4d0cd317ded7.png)


4. Add Security Context to tenant
```
k -n tenant-lite edit tenants.minio.min.io  
```
```
    securityContext:
      runAsUser: 1000
      runAsGroup: 1000
      runAsNonRoot: true
      fsGroup: 1000
```
![image](https://user-images.githubusercontent.com/16472240/213007244-7421b513-61b8-45ed-a6ee-3b1ecdf7bcb4.png)

5. Restart the tenant pods, and observe them in a ready state
```
k -n tenant-lite delete pod/storage-lite-pool-0-0
k -n tenant-lite delete pod/storage-lite-pool-0-1
k -n tenant-lite delete pod/storage-lite-pool-0-2
k -n tenant-lite delete pod/storage-lite-pool-0-3
```

```
k -n tenant-lite get pods | grep "pool-0"
```

![image](https://user-images.githubusercontent.com/16472240/213008104-2ff7b16d-84ed-46ca-8acb-f4063ca4cb58.png)

## Fix
1. Modify pkg/resources/statefulsets/minio-statefulset.go addingin only non-null fields to avoid the NPE.
```
        // Default to Pod values
	if pool.SecurityContext != nil {
		if pool.SecurityContext.RunAsNonRoot != nil {
			runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
		}
		if pool.SecurityContext.RunAsUser != nil {
			runAsUser = *pool.SecurityContext.RunAsUser
		}
		if pool.SecurityContext.RunAsGroup != nil {
			runAsGroup = *pool.SecurityContext.RunAsGroup
		}
	}
```

## Test
1. Clone https://github.com/allanrogerr/operator/tree/fix-security-context-npe
Deploy and maintain a kind cluster with tenant-lite. e.g. with `testing/deploy-tenant.sh` in the operator repo.
Ensure that the `destroy_kind` command is commented out.

2. Once the tenant pods are online, edit the tenant ensuring the following is under `.spec.pools`, with `k -n tenant-lite edit tenants.minio.min.io`:
```
    securityContext:
      #runAsUser: 1000
      #runAsGroup: 1000
      #runAsNonRoot: true
      fsGroup: 1000
    containerSecurityContext:
      runAsUser: 1000       
      runAsGroup: 1000
      runAsNonRoot: true
```

![image](https://user-images.githubusercontent.com/16472240/213004912-234492c8-e610-4745-8d45-58535bd556ae.png)


3. Restart the tenant pods, and observe them in a ready state
```
k -n tenant-lite delete pod/storage-lite-pool-0-0
k -n tenant-lite delete pod/storage-lite-pool-0-1
k -n tenant-lite delete pod/storage-lite-pool-0-2
k -n tenant-lite delete pod/storage-lite-pool-0-3
```
```
k -n tenant-lite get pods | grep "pool-0"
```
![image](https://user-images.githubusercontent.com/16472240/213009804-447ac7d5-e054-482d-a470-1a2f411615bc.png)
