### PR TITLE
Control the start of event reporting for expiring certificates

### DIFF
--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -224,6 +224,9 @@ spec:
   ## Enable automatic Kubernetes based certificate generation and signing as explained in
   ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
   requestAutoCert: true
+  # The minimum number of days to expiry before an alert for an expiring certificate is fired.
+  # In the below example, if a given certificate will expire in 7 days then expiration events will only be triggered 1 day before expiry
+  # certExpiryAlertThreshold: 1
   ## Prometheus setup for MinIO Tenant.
   #  prometheus:
   #    image: "" # defaults to quay.io/prometheus/prometheus:RELEASE.2024-07-11T18-01-28Z

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -875,6 +875,9 @@ spec:
                       type: string
                     type: array
                 type: object
+              certExpiryAlertThreshold:
+                format: int64
+                type: integer
               configuration:
                 properties:
                   name:

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -94,6 +94,9 @@ spec:
   externalCertSecret: {{- toYaml . | nindent 6 }}
   {{- end }}
   requestAutoCert: {{ dig "certificate" "requestAutoCert" false . }}
+  {{- if ((.certificate).certExpiryAlertThreshold) }}
+  certExpiryAlertThreshold: {{ ((.certificate).certExpiryAlertThreshold) }}
+  {{- end }}
   {{- if dig "s3" "bucketDNS" false . }}
     {{- fail "Value 'tenant.s3.bucketDNS' is deprecated since Operator v4.3.2, use 'tenant.features.bucketDNS' instead" }}
   {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -268,6 +268,10 @@ tenant:
     # Enable automatic Kubernetes based `certificate generation and signing <https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster>`__
     requestAutoCert: true
     ###
+    # The minimum number of days to expiry before an alert for an expiring certificate is fired.
+    # In the below example, if a given certificate will expire in 7 days then expiration events will only be triggered 1 day before expiry
+    # certExpiryAlertThreshold: 1
+    ###
     # This field is used only when ``requestAutoCert: true``.
     # Use this field to set CommonName for the auto-generated certificate. 
     # MinIO defaults to using the internal Kubernetes DNS name for the pod

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -235,6 +235,10 @@ type TenantSpec struct {
 	// +optional
 	RequestAutoCert *bool `json:"requestAutoCert,omitempty"`
 
+	// CertExpiryAlertThreshold is the minimum number of days to expiry before an alert for an expiring certificate is fired.
+	// +optional
+	CertExpiryAlertThreshold *int64 `json:"certExpiryAlertThreshold,omitempty"`
+
 	// Liveness Probe for container liveness. Container will be restarted if the probe fails.
 	// +optional
 	Liveness *corev1.Probe `json:"liveness,omitempty"`

--- a/pkg/controller/custom.go
+++ b/pkg/controller/custom.go
@@ -108,17 +108,21 @@ func (c *Controller) getCustomCertificates(ctx context.Context, tenant *miniov2.
 				expiresInSeconds := int64(math.Mod(expiresIn.Seconds(), 60))
 				expiresInHuman := fmt.Sprintf("%v days, %v hours, %v minutes, %v seconds", expiresInDays, expiresInHours, expiresInMinutes, expiresInSeconds)
 
-				if expiresInDays >= 10 && expiresInDays < 30 {
-					c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpiring", fmt.Sprintf("%s certificate '%s' is expiring in %d days", certType, secret.Name, expiresInDays))
-				}
-				if expiresInDays > 0 && expiresInDays < 10 {
-					c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpiryImminent", fmt.Sprintf("%s certificate '%s' is expiring in %d days", certType, secret.Name, expiresInDays))
+				if tenant.Spec.CertExpiryAlertThreshold == nil || expiresInDays < *tenant.Spec.CertExpiryAlertThreshold {
+					if expiresInDays >= 10 && expiresInDays < 30 {
+						c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpiring", fmt.Sprintf("%s certificate '%s' is expiring in %d days", certType, secret.Name, expiresInDays))
+					}
+					if expiresInDays > 0 && expiresInDays < 10 {
+						c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpiryImminent", fmt.Sprintf("%s certificate '%s' is expiring in %d days", certType, secret.Name, expiresInDays))
+					}
+					if expiresIn <= 0 {
+						c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpired", fmt.Sprintf("%s certificate '%s' has expired", certType, secret.Name))
+					}
 				}
 				if expiresIn > 0 && expiresIn < 24*time.Hour {
 					expiresInHuman = fmt.Sprintf("%v hours, %v minutes, and %v seconds", expiresInHours, expiresInMinutes, expiresInSeconds)
 				}
 				if expiresIn <= 0 {
-					c.recorder.Event(tenant, corev1.EventTypeWarning, "CertificateExpired", fmt.Sprintf("%s certificate '%s' has expired", certType, secret.Name))
 					expiresInHuman = "EXPIRED"
 				}
 

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -875,6 +875,9 @@ spec:
                       type: string
                     type: array
                 type: object
+              certExpiryAlertThreshold:
+                format: int64
+                type: integer
               configuration:
                 properties:
                   name:


### PR DESCRIPTION
### Issue summary
In cases where users install certificates of short duration, kubernetes events are spammed with multiple warnings of certificate expiry. This is undesirable. A means on reducing the number of warnings produced is more desirable.
See https://github.com/minio/operator/issues/1791
in the tenant crd, `.spec.certExpiryAlertThreshold` represents the minimum number of days to expiry before an alert for an expiring certificate is fired.
For example considering `.spec.certExpiryAlertThreshold = 1`, if a given certificate will expire in 7 days then expiration events will only be triggered 1 day before expiry

### Test summary

1. Build and install the minio operator
2. Apply a tenant with Helm or Kustomize
3. Create expired and expiring certificates
4. Create secrets based on these
5. Apply the secrets as external certificates
6. Experiment with different values of `certExpiryAlertThreshold` e.g.
7. Observe

* if certExpiryAlertThreshold is not present then all certificate expiry events are reported
* if the whole number of days left for a certificate to expire is less than certExpiryAlertThreshold then this certificate expiry events are reported
* if the whole number of days left for a certificate to expire is greater than or equal to certExpiryAlertThreshold then this certificate expiry events are not reported

Verbose tests here:
https://github.com/allanrogerr/public/wiki/operator%E2%80%901791

Fixes: 